### PR TITLE
Using local resource for ffmpeg-core dependency in place of cdn

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,10 +17,13 @@ import InputVideo from "./components/Inputvideo";
 import ResultImg from "./components/Resultimg";
 import HelpIcon from "./components/help-modal/HelpIcon";
 
+// local resource for ffmpeg-core wasm dependency
+const corePathURL = new URL('../ffmpeg_core_dist/ffmpeg-core.js', import.meta.url).href
+
 // Create the FFmpeg instance and load it
 const ffmpeg = createFFmpeg({
   log: true,
-  corePath: "https://unpkg.com/@ffmpeg/core@0.10.0/dist/ffmpeg-core.js",
+  corePath: corePathURL
 });
 
 function LinearProgressWithLabel({ value, ...rest }) {


### PR DESCRIPTION
Followed the instructions for self hosting listed on ffmpeg libraries docs
https://github.com/ffmpegwasm/ffmpeg.wasm#use-other-version-of-ffmpegwasm-core--ffmpegcore

### Testing

Did some manual testing and the development enviroment works as expected

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/26678464/199344411-78e6f149-e975-482c-88ae-48b808d24a3f.png">

##### Gif generated with branch changes
![Screen Recording 2022-11-01 at 2 21 20 PM mov](https://user-images.githubusercontent.com/26678464/199344499-14d706dd-1f55-45b6-bca1-7f68bd11684f.gif)


